### PR TITLE
readme: simplify composer step

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,13 @@ In older builds "ß" was mapped to "ss". Should you still need this behaviour, s
 
 ### Via Composer
 
-```php
-{
-    "require" : {
-        "algo26-matthias/idna-convert" : "2.*"
-    }
-}
+```
+composer require algo26-matthias/idna-convert
 ```
 
 ### Official ZIP Package
 
 The official ZIP packages are discontinued. Stick to Composer or Github to acquire your copy, please.
-
 
 ## Examples
 


### PR DESCRIPTION
no need to manually edit files, besides this is the syntax packagist recommends if you visit the package page.

it picks best version for you based on release and compatible php runtime