### PR TITLE
fix 'Array and string offset access syntax with curly braces is deprecated' note in php-7.4

### DIFF
--- a/src/EncodingHelper/FromUtf8.php
+++ b/src/EncodingHelper/FromUtf8.php
@@ -58,7 +58,7 @@ class FromUtf8 implements EncodingHelperInterface
     {
         $return = '';
         for ($i = 0; $i < strlen($string); ++$i) {
-            $codePoint = ord($string{$i});
+            $codePoint = ord($string[$i]);
             switch ($codePoint) {
                 case 196:
                     $return .= chr(142);

--- a/src/EncodingHelper/ToUtf8.php
+++ b/src/EncodingHelper/ToUtf8.php
@@ -58,7 +58,7 @@ class ToUtf8 implements EncodingHelperInterface
     {
         $return = '';
         for ($i = 0; $i < strlen($string); ++$i) {
-            $codePoint = ord($string{$i});
+            $codePoint = ord($string[$i]);
             switch ($codePoint) {
                 case 129:
                     $return .= chr(252);


### PR DESCRIPTION
The array and string offset access syntax using curly braces is deprecated. Use $var[$idx] instead of $var{$idx}.

 See https://www.php.net/manual/de/migration74.deprecated.php