### PR TITLE
Enable testing against PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: php
 php:
-  - '7.2'
-  - '7.3'
+  - 7.2
+  - 7.3
+  - 7.4
+  - nightly
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php:
+        - nightly
 
 before_install:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "ext-pcre": "*",
-        "php": "^7.2.0",
+        "php": ">=7.2.0",
         "jakeasmith/http_build_url": "^1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "jakeasmith/http_build_url": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "7.5.14"
+        "phpunit/phpunit": "^8.0 || ^9.0"
     },
     "suggest":  {
         "ext-mbstring": "Install ext/mbstring for using input / output other than UTF-8 or ISO-8859-1",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          forceCoversAnnotation="true"
          beStrictAboutCoversAnnotation="true"

--- a/tests/integration/ToIdnTest.php
+++ b/tests/integration/ToIdnTest.php
@@ -7,6 +7,9 @@ use Algo26\IdnaConvert\Exception\InvalidIdnVersionException;
 use Algo26\IdnaConvert\ToIdn;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Algo26\IdnaConvert\ToIdn
+ */
 class ToIdnTest extends TestCase
 {
     /**

--- a/tests/integration/ToUnicodeTest.php
+++ b/tests/integration/ToUnicodeTest.php
@@ -5,6 +5,9 @@ use Algo26\IdnaConvert\Exception\InvalidIdnVersionException;
 use Algo26\IdnaConvert\ToUnicode;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Algo26\IdnaConvert\ToUnicode
+ */
 class ToUnicodeTest extends TestCase
 {
     /**

--- a/tests/unit/namePrepTest.php
+++ b/tests/unit/namePrepTest.php
@@ -8,6 +8,9 @@ use Algo26\IdnaConvert\NamePrep\NamePrep;
 use Algo26\IdnaConvert\TranscodeUnicode\TranscodeUnicode;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Algo26\IdnaConvert\NamePrep\NamePrep
+ */
 class namePrepTest extends TestCase
 {
     /** @var TranscodeUnicode */
@@ -16,7 +19,7 @@ class namePrepTest extends TestCase
     /** @var NamePrep */
     private $namePrep2003;
 
-    public function setup()
+    public function setup(): void
     {
         $this->uctc = new TranscodeUnicode();
         $this->namePrep2003 = new NamePrep(2003);


### PR DESCRIPTION
- Update Composer PHP requirement to allow PHP 8.0
- Update Travis-CI configuration to test against PHP 7.4 and PHP nightly (8.0rc1 at present)