### PR TITLE
refactor deprecated array/string accessor syntax {} to []

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,38 @@
 /composer.phar
 /composer.lock
 /vendor
+
+
+
+##################################
+#                                #
+#   Editors + OS related files   #
+#                                #
+##################################
+
+
+# Eclipse
+/.settings
+/.buildpath
+/.project
+
+
+# PhpStorm
+/.idea
+
+
+# NetBeans
+/nbproject
+
+
+# MS Code
+/.vscode
+
+
+# Mac OS
+*.DS_Store
+*.swp
+*.orig
+*.tar
+*.cpgz
+

--- a/src/Punycode.php
+++ b/src/Punycode.php
@@ -120,7 +120,7 @@ class Punycode implements PunycodeInterface
         $delim_pos = strrpos($encoded, '-');
         if ($delim_pos > self::byteLength(self::punycodePrefix)) {
             for ($k = self::byteLength(self::punycodePrefix); $k < $delim_pos; ++$k) {
-                $decoded[] = ord($encoded{$k});
+                $decoded[] = ord($encoded[$k]);
             }
         }
         $deco_len = count($decoded);
@@ -134,7 +134,7 @@ class Punycode implements PunycodeInterface
 
         for ($enco_idx = ($delim_pos) ? ($delim_pos + 1) : 0; $enco_idx < $enco_len; ++$deco_len) {
             for ($old_idx = $idx, $w = 1, $k = self::base; 1; $k += self::base) {
-                $digit = $this->decodeDigit($encoded{$enco_idx++});
+                $digit = $this->decodeDigit($encoded[$enco_idx++]);
                 $idx += $digit * $w;
                 $t = ($k <= $bias) ? self::tMin :
                         (($k >= $bias + self::tMax) ? self::tMax : ($k - $bias));

--- a/src/UnicodeTranscoder.php
+++ b/src/UnicodeTranscoder.php
@@ -82,7 +82,7 @@ class UnicodeTranscoder implements UnicodeTranscoderInterface
         $mode = 'next';
         $test = 'none';
         for ($k = 0; $k < $inp_len; ++$k) {
-            $v = ord($input{$k}); // Extract byte from input string
+            $v = ord($input[$k]); // Extract byte from input string
 
             if ($v < 128) { // We found an ASCII char - put into stirng as is
                 $output[$out_len] = $v;
@@ -203,7 +203,7 @@ class UnicodeTranscoder implements UnicodeTranscoderInterface
         $b64 = '';
 
         for ($k = 0; $k < $inp_len; ++$k) {
-            $c = $input{$k};
+            $c = $input[$k];
 
             // Ignore zero bytes
             if (0 == ord($c)) {
@@ -225,10 +225,10 @@ class UnicodeTranscoder implements UnicodeTranscoderInterface
                     $tmp = substr($tmp, -1 * (strlen($tmp) % 2));
                     for ($i = 0; $i < strlen($tmp); $i++) {
                         if ($i % 2) {
-                            $output[$out_len] += ord($tmp{$i});
+                            $output[$out_len] += ord($tmp[$i]);
                             $out_len++;
                         } else {
-                            $output[$out_len] = ord($tmp{$i}) << 8;
+                            $output[$out_len] = ord($tmp[$i]) << 8;
                         }
                     }
                     $mode = 'd';
@@ -336,12 +336,12 @@ class UnicodeTranscoder implements UnicodeTranscoderInterface
                 $out_len++;
                 $output[$out_len] = 0;
             }
-            $output[$out_len] += ord($input{$i}) << (8 * (3 - ($i % 4)));
+            $output[$out_len] += ord($input[$i]) << (8 * (3 - ($i % 4)));
         }
 
         return $output;
     }
-    
+
     /**
      * Gets the length of a string in bytes even if mbstring function
      * overloading is turned on
@@ -356,5 +356,5 @@ class UnicodeTranscoder implements UnicodeTranscoderInterface
         }
 
         return strlen((binary) $string);
-    }    
+    }
 }


### PR DESCRIPTION
For error @ PHP8
PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in /idna-convert/src/UnicodeTranscoder.php on line 206

"jsmitty12/phpwhois" is affected.