### PR TITLE
Fix endless loop with expanded ASCII codepoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.idea
 !.gitkeep
-/phpunit.phar
-/composer.phar
+.phpunit.result.cache
 /composer.lock
 /vendor

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "jakeasmith/http_build_url": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.0"
+        "phpunit/phpunit": "8.0"
     },
     "suggest":  {
         "ext-mbstring": "Install ext/mbstring for using input / output other than UTF-8 or ISO-8859-1",

--- a/src/NamePrep/NamePrep.php
+++ b/src/NamePrep/NamePrep.php
@@ -240,9 +240,7 @@ class NamePrep implements NamePrepInterface
      */
     private function getCombiningClass(int $char): int
     {
-        return isset($this->namePrepData->normalizeCombiningClasses[$char])
-            ? $this->namePrepData->normalizeCombiningClasses[$char]
-            : 0;
+        return $this->namePrepData->normalizeCombiningClasses[$char] ?? 0;
     }
 
     /**

--- a/tests/integration/ToIdnTest.php
+++ b/tests/integration/ToIdnTest.php
@@ -153,6 +153,8 @@ class ToIdnTest extends TestCase
             ['fußball.example', 'xn--fuball-cta.example'],
             ['היפא18פאטאם', 'xn--18-uldcat6ad6bydd'],
             ['فرس18النهر', 'xn--18-dtd1bdi0h3ask'],
+            ["\u{33c7}", 'xn--czk'],
+            ["\u{37a}", 'xn--1va'],
         ];
     }
 
@@ -165,6 +167,8 @@ class ToIdnTest extends TestCase
             ['weißenbach', 'weissenbach'],
             ['☃.example', 'xn--n3h.example'],
             ['fußball.example', 'fussball.example'],
+            ["\u{33c7}", 'co.'],
+            ["\u{37a}", 'xn-- -gmb'],
         ];
     }
 


### PR DESCRIPTION
We consciously decided to take care of domain names only in the beginning of the project. This poses a problem in cases, where certain Unicode codepoints appear in the input, which are expanded into basic codepoints outside the range [-a-zA-z0-9]. Those were dropped during the first step and ignored in the second step of converting them to Punycode.  Eventually, the loop for step two never reached the end because it tried to convert characters not being there - resulting in an endless loop.

By simply copying all ASCII characters to the output as per the RFCs, the loop is fixed.