### PR TITLE
Make intl dependency optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     ],
     "require": {
         "ext-pcre": "*",
-        "ext-intl": "*",
         "php": ">=8.1",
         "jakeasmith/http_build_url": "^1"
     },
@@ -22,7 +21,8 @@
     },
     "suggest":  {
         "ext-mbstring": "Install ext/mbstring for using input / output other than UTF-8 or ISO-8859-1",
-        "ext-iconv": "Install ext/iconv for using input / output other than UTF-8 or ISO-8859-1"
+        "ext-iconv": "Install ext/iconv for using input / output other than UTF-8 or ISO-8859-1",
+		"ext-intl": "Install ext/intl for better case folding"
     },
     "autoload": {
         "psr-4": {

--- a/src/NamePrep/NamePrep.php
+++ b/src/NamePrep/NamePrep.php
@@ -60,7 +60,7 @@ class NamePrep implements NamePrepInterface
 
     private function applyCaseFolding(array $inputArray): array
     {
-        if ($this->namePrepData->version !== 2008) {
+        if ($this->namePrepData->version !== 2008 || !class_exists(IntlChar::class)) {
             return $inputArray;
         }
 


### PR DESCRIPTION
#46 introduced a hard dependency to the intl extension, which might be treated as bc break. This pr checks if the intl class exists and then does the case folding. Additionally will the intl requirement be removed and instead added as suggestion. This improves migration from version 3 on hosts without the intl extension.